### PR TITLE
Add badges for SCF API Slack channel

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -25,6 +25,7 @@
             <li><a href="http://help.seeclickfix.com/kb/api/api-overview" target="_blank">v1 (deprecated)</a></li>
             <li><a href="http://seeclickfix.com" target="_blank">SeeClickFix.com</a></li>
             <li><a href="http://seeclickfix.com/contact_us" target="_blank">Support</a></li>
+            <li><script async defer src="https://seeclickfix-api-slack.herokuapp.com/slackin.js"></script></li>
           </ul>
         </div>
       </div><!-- #header -->
@@ -84,6 +85,13 @@
       <div class="sidebar-module">
         <p>This website is a <a href="https://github.com/SeeClickFix/dev.seeclickfix.com" target="_blank">public GitHub repository</a>. Please help us by forking the project and adding to it.</p>
       </div>
+
+      <div class="sidebar-module">
+        <!-- SCF API Slack badge -->
+        <p>Developers, looking to share ideas or ask questions about the SCF API? Join the Slack channel!<br/><br/>
+        <script async defer src="https://seeclickfix-api-slack.herokuapp.com/slackin.js?large"></script></p>
+      </div>
+
     </div><!-- /sidebar-shell -->
 
     </div><!-- #wrapper -->


### PR DESCRIPTION
@ren I thought I could use this for Yale Hackathon, at least for devs to talk to each other. This does not replace our dedicated *Support* link, obviously.

The full signup/landing page is at [seeclickfix-api-slack.herokuapp.com](http://seeclickfix-api-slack.herokuapp.com), but these badges mean we don't need to send that link around.