### PR TITLE
Remove link to redundant Data License content

### DIFF
--- a/content/v2.md
+++ b/content/v2.md
@@ -205,8 +205,6 @@ SeeClickFix data sources, including XML, RSS, KML and JSON, are licensed under a
 
 Persons or organizations wishing to reuse large portions (ie., more than occasional queries ) of data are required to contact us first at <support@seeclickfix.com>. We are very interested in working with researchers and/or agencies to ensure that this data is put to good use!
 
-<http://www.seeclickfix.com/open_data>
-
 ### API Rate Limits
 
 The rate limit allows for up to 20 requests per minute. 


### PR DESCRIPTION
The content at https://seeclickfix.com/open_data is identical to what is already embedded on this page.