### PR TITLE
[SCF-1392] update documentation to reflect new contact email process

### DIFF
--- a/content/v2.md
+++ b/content/v2.md
@@ -8,7 +8,7 @@ Use of the API documented here is subject to the terms of our Data License below
 
 This describes the resources that make up the official SeeClickFix API v2. If
 you have any problems or requests please contact
-[Developer Support](mailto:developer-support@seeclickfix.com).
+[Developer Support](mailto:seeclickfix@civicplus.help).
 
 SeeClickFix provides an open311 compatible API at [http://seeclickfix.com/open311](http://seeclickfix.com/open311).
 
@@ -203,7 +203,7 @@ email to the creator will be delivered with Spanish translations.
 
 SeeClickFix data sources, including XML, RSS, KML and JSON, are licensed under a Creative Commons Attribution-Noncommercial-Share Alike 3.0 United States License. Attribution should be to seeclickfix.com.
 
-Persons or organizations wishing to reuse large portions (ie., more than occasional queries ) of data are required to contact us first at <support@seeclickfix.com>. We are very interested in working with researchers and/or agencies to ensure that this data is put to good use!
+Persons or organizations wishing to reuse large portions (ie., more than occasional queries ) of data are required to contact us first at <seeclickfix@civicplus.help>. We are very interested in working with researchers and/or agencies to ensure that this data is put to good use!
 
 ### API Rate Limits
 
@@ -257,5 +257,5 @@ If an application abuses the rate limits, we will return a HTTP 403 Forbidden er
     }
 
 
-If you or your application has been blacklisted and you think there has been a mistake, please contact us at <support@seeclickfix.com>
+If you or your application has been blacklisted and you think there has been a mistake, please contact us at <seeclickfix@civicplus.help>
 

--- a/content/v2/overview/authentication.md
+++ b/content/v2/overview/authentication.md
@@ -36,7 +36,7 @@ The [Doorkeeper documentation](https://github.com/doorkeeper-gem/doorkeeper/wiki
 
 Before an application (API client) can use OAuth2 with SeeClickFix it must be registered
 with our system. Register your app by sending the following information to
-developer-support@seeclickfix.com:
+seeclickfix@civicplus.help:
 
 1. Name of Application
 1. Organization Name


### PR DESCRIPTION
find “@seeclickfix.com” and replace support emails with technical support email address: seeclickfix@civicplus.help